### PR TITLE
add new isHttpUrl validator

### DIFF
--- a/lib/valve.js
+++ b/lib/valve.js
@@ -794,6 +794,28 @@ Chain.prototype.isUrl = function() {
 };
 
 
+/**
+ * Adds a validator to the chain to ensure that the validated data is a
+ * valid-looking URL.
+ *
+ * @return {Chain} The validator chain to which the validator was added.
+ */
+Chain.prototype.isHttpUrl = function() {
+  this._pushValidator({
+    name: 'isUrl',
+    func: function(value, baton, callback) {
+      if (!check.isURL(value, { protocols: ['http', 'https'], require_protocol: true })) {
+        callback('Invalid URL');
+        return;
+      }
+      callback(null, value);
+    },
+    help: 'URL'
+  });
+  return this;
+};
+
+
 /*
  * Adds a validator to the chain to ensure that the validated data is a
  * valid-looking IPv4 or IPv6 address.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "async": "0.1.18",
-    "validator": "3.19.0",
+    "validator": "3.41.1",
     "ipv6": "2.0.2",
     "elementtree": "0.1.6",
     "sprintf": "0.1.1"

--- a/tests/test-valve.js
+++ b/tests/test-valve.js
@@ -396,10 +396,57 @@ exports['test_validate_url'] = function(test, assert) {
     assert.deepEqual(cleaned, obj, 'URL test');
   });
 
+  // ftp test
+  var ftp_url = { a: "ftp://rackspace.com" };
+  v.check(ftp_url, function(err, cleaned) {
+    assert.ifError(err);
+    assert.deepEqual(cleaned, ftp_url, 'FTP URL test');
+  });
+
+  // no protocol test
+  var no_proto = { a: "rackspace.com" };
+  v.check(no_proto, function(err, cleaned) {
+    assert.ifError(err);
+    assert.deepEqual(cleaned, no_proto, "URL test with no protocol specified");
+  });
+
   // negative case
   var neg = { a: 'invalid/' };
   v.check(neg, function(err, cleaned) {
     assert.deepEqual(err.message, 'Invalid URL', 'URL test (negative case)');
+  });
+  test.finish();
+};
+
+exports['test_validate_http_url'] = function(test, assert) {
+  var v = new V({
+    a: C().isHttpUrl()
+  });
+
+  // positive case
+  var obj = { a: 'http://www.cloudkick.com' };
+  var obj_ext = { a: 'http://www.cloudkick.com', b: 2 };
+  v.check(obj_ext, function(err, cleaned) {
+    assert.ifError(err);
+    assert.deepEqual(cleaned, obj, 'URL test');
+  });
+
+  // ftp test
+  var ftp_url = { a: 'ftp://rackspace.com' };
+  v.check(ftp_url, function(err, cleaned) {
+    assert.deepEqual(err.message, 'Invalid URL', 'HTTP URL test with FTP URL');
+  });
+
+  // no protocol test
+  var no_proto = { a: 'rackspace.com' };
+  v.check(no_proto, function(err, cleaned) {
+    assert.deepEqual(err.message, 'Invalid URL', 'HTTP URL test with no protocol specified');
+  });
+
+  // negative case
+  var neg = { a: 'invalid/' };
+  v.check(neg, function(err, cleaned) {
+    assert.deepEqual(err.message, 'Invalid URL', 'HTTP URL test (negative case)');
   });
   test.finish();
 };


### PR DESCRIPTION
This bumps validator.js and adds a new `isHttpUrl` validator.  Needed to bumb `validator` so that we could include the additional `options` parameter.


If the protocol is excluded from a URL when added to noit, noit will use the `check.target` as the host and set the path to `/` rather than using the full path in the URL.

We should use this new validator in ele to ensure the protocol is included where it is needed.