### PR TITLE
Add v4 uuid validators

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -14,12 +14,32 @@ exports.isPort = function(value, baton) {
 
 
 exports.isV1UUID = function(str) {
+  this.isUUID(str);
+
+  if (str.charAt(14) !== '1') {
+    throw new Error('UUID is not version 1');
+  }
+
+  return str;
+};
+
+
+exports.isV4UUID = function(str) {
+  this.isUUID(str);
+
+  if (str.charAt(14) !== '4') {
+    throw new Error('UUID is not version 4');
+  }
+
+  return str;
+};
+
+
+exports.isUUID = function(str) {
   if (!str.match(/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/)) {
     throw new Error('Invalid UUID');
   } else if ((parseInt(str.charAt(19), 16) & 12) !== 8) {
     throw new Error('Unsupported UUID variant');
-  } else if (str.charAt(14) !== '1') {
-    throw new Error('UUID is not version 1');
   }
 
   return str;

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -2008,6 +2008,30 @@ Chain.prototype.isV1UUID = function() {
 
 
 /**
+ * Adds a validator to the chain that checks for valid v4 UUIDs.
+ *
+ * @return {Chain} The validator chain to which the validator was added.
+ */
+Chain.prototype.isV4UUID = function() {
+  this._pushValidator({
+    name: 'isV4UUID',
+    func: function(value, baton, callback) {
+      try {
+        value = validators.isV4UUID(value);
+      } catch (e) {
+        callback(e.message);
+        return;
+      }
+
+      callback(null, value);
+    },
+    help: 'Version 4 UUID'
+  });
+  return this;
+};
+
+
+/**
  * Adds a validator to the chain that marks the key in its schema as
  * immutable: if the key is present in the partial check, an error will
  * be returned.

--- a/tests/test-valve.js
+++ b/tests/test-valve.js
@@ -2688,6 +2688,65 @@ exports['test_V1UUID'] = function(test, assert) {
   });
 };
 
+exports['test_V4UUID'] = function(test, assert) {
+  var v = new V({
+    a: new C().isV4UUID()
+  });
+
+  async.series([
+    function(callback) {
+      // positive case
+      var pos = { a: '4b299c10-ab5a-41e1-9f6f-1c8b12469d15' };
+      v.check(pos, function(err, cleaned) {
+        assert.ifError(err);
+        assert.deepEqual(cleaned, pos, 'isV4UUID test');
+        callback();
+      });
+
+    },
+
+    function(callback) {
+      // negative case 0
+      var neg0 = { a: 'b299c10-ab5a-11e1-9f6f-1c8b12469d15' };
+      v.check(neg0, function(err, cleaned) {
+        assert.deepEqual(err.message, "Invalid UUID", 'isV4UUID test');
+        callback();
+      });
+    },
+
+    function(callback) {
+      // negative case 1
+      var neg1 = { a: '4@299c10-ab5a-11e1-9f6f-1c8b12469d15' };
+      v.check(neg1, function(err, cleaned) {
+        assert.deepEqual(err.message, "Invalid UUID", 'isV4UUID test');
+        callback();
+      });
+    },
+
+    function(callback) {
+      //negative case 2
+      var neg2 = { a : '4b299c10-ab5a-11e1-4f6f-1c8b12469d15' };
+      v.check(neg2, function(err, cleaned) {
+        assert.deepEqual(err.message, "Unsupported UUID variant", 'isV4UUID test');
+        callback();
+      });
+    },
+
+    function(callback) {
+      //negative case 3
+      var neg3 = { a : '4b299c10-ab5a-21e1-9f6f-1c8b12469d15' };
+      v.check(neg3, function(err, cleaned) {
+        assert.deepEqual(err.message, "UUID is not version 4", 'isV4UUID test');
+        callback();
+      });
+    }
+  ],
+
+  function(err) {
+    test.finish();
+  });
+};
+
 exports['test_getValidatorPos_hasValidator_and_getValidatorAtPos'] = function(test, assert) {
   var v = new V({
     a: C().len(1).isNumeric(),


### PR DESCRIPTION
This is code that was previously added directly to ele (minus the tests) rather than being included into swiz.  Since we now need to bump the swiz version in ele, this not being here screws things up.