### PR TITLE
Use ip-address module instead of ipv6

### DIFF
--- a/lib/cidr.js
+++ b/lib/cidr.js
@@ -19,7 +19,6 @@ var Buffer = require('buffer').Buffer;
 
 var Address4 = require('ip-address').Address4;
 var Address6 = require('ip-address').Address6;
-var BigInteger = require('ipv6/lib/node/bigint').BigInteger;
 
 var BitBuffer = require('./bitbuffer').BitBuffer;
 

--- a/lib/cidr.js
+++ b/lib/cidr.js
@@ -17,7 +17,8 @@
 
 var Buffer = require('buffer').Buffer;
 
-var ipv6 = require('ipv6').v6;
+var Address4 = require('ip-address').Address4;
+var Address6 = require('ip-address').Address6;
 var BigInteger = require('ipv6/lib/node/bigint').BigInteger;
 
 var BitBuffer = require('./bitbuffer').BitBuffer;
@@ -56,7 +57,7 @@ var bigIntToByteArray = function(v, size) {
 
 var makeAddr = function(ad, ver) {
   if (ver === 6) {
-    var adr = new ipv6.Address(ad);
+    var adr = new Address6(ad);
 
     if (adr.error) {
       throw new Error('Invalid IPv6: ' + ad);
@@ -82,6 +83,7 @@ var CIDR = function(x, y) {
   var ip,
     bits,
     arr,
+    ip4,
     ip6;
   if (y === undefined) { // handed a string
     arr = x.split('/');
@@ -93,8 +95,10 @@ var CIDR = function(x, y) {
   }
 
 
-  ip6 = (ip instanceof ipv6.Address ? ip : new ipv6.Address(ip));
-  this.v = (ip6.is4() ? 4 : (ip6.valid ? 6 : 0));
+  ip4 = (ip instanceof Address4 ? ip : new Address4(ip));
+  ip6 = (ip instanceof Address6 ? ip : new Address6(ip));
+
+  this.v = (ip4.valid ? 4 : (ip6.valid ? 6 : 0));
 
   if (this.v === 6) {
     bits = 128;
@@ -116,10 +120,12 @@ var CIDR = function(x, y) {
 CIDR.prototype.isInCIDR = function(x) {
   var ver,
     buf1,
+    ip4,
     ip6;
 
-  ip6 = new ipv6.Address(x);
-  ver = (ip6.is4() ? 4 : (ip6.valid ? 6 : 0));
+  ip4 = new Address4(x);
+  ip6 = new Address6(x);
+  ver = (ip4.valid ? 4 : (ip6.valid ? 6 : 0));
 
   if (ver !== this.v) {
     return false;

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -56,14 +56,14 @@
  * });
  */
 
-var async = require('async'),
-    check = require('validator'),
-    validators = require('./validators'),
-    utils = require('./util'),
-    net = require('net'),
-    ipv6 = require('ipv6').v6,
-    ipv4 = require('ipv6').v4,
-    Cidr = require('./cidr').CIDR;
+var async = require('async');
+var check = require('validator');
+var validators = require('./validators');
+var utils = require('./util');
+var net = require('net');
+var Address4 = require('ip-address').Address4;
+var Address6 = require('ip-address').Address6;
+var Cidr = require('./cidr').CIDR;
 
 var entities = {
   '&nbsp;': '\u00a0',
@@ -443,7 +443,7 @@ function chainHelp(chain) {
 function normalizeIP(addr) {
   var claimsToBeIPv6 = /:/.test(addr);
   if(claimsToBeIPv6) {
-    var ip6 = new ipv6.Address(addr);
+    var ip6 = new Address6(addr);
     if(ip6.valid) {
       return ip6.canonicalForm();
     } else if(ip6.error) {
@@ -454,7 +454,7 @@ function normalizeIP(addr) {
   } else {
     var isIPv4 = false;
     try {
-      var ip4 = new ipv4.Address(addr);
+      var ip4 = new Address4(addr);
       isIPv4 = ip4.valid;
     }
     //  Any exception thrown implies not a valid IPv4 address.
@@ -664,10 +664,12 @@ Chain.prototype.notIPBlacklisted = function() {
           l,
           r,
           blacklisted,
+          ip4,
           ip6;
 
-      ip6 = new ipv6.Address(value);
-      ipVersion = (ip6.is4() ? 4 : (ip6.valid ? 6 : 0));
+      ip4 = new Address4(value);
+      ip6 = new Address6(value);
+      ipVersion = (ip4.valid ? 4 : (ip6.valid ? 6 : 0));
 
       if (!ipVersion) {
         callback('Invalid IP');
@@ -719,9 +721,9 @@ Chain.prototype.isCIDR = function() {
       }
       addr = cidr[0];
 
-
-      ip6 = new ipv6.Address(addr);
-      ipVersion = (ip6.is4() ? 4 : (ip6.valid ? 6 : 0));
+      ip4 = new Address4(addr);
+      ip6 = new Address6(addr);
+      ipVersion = (ip4.valid ? 4 : (ip6.valid ? 6 : 0));
       if (! ipVersion) {
         callback('Invalid IP');
         return;
@@ -830,7 +832,7 @@ Chain.prototype.isAddressPair = function() {
     name: 'isAddressPair',
     func: function(value, baton, callback) {
       var idx = value.lastIndexOf(':'),
-          ip, port, cleaned;
+          ip, ip4, ip6, port, cleaned;
 
       if (idx === -1) {
         callback('Missing semicolon (:) Address must be in the following ' +
@@ -842,9 +844,10 @@ Chain.prototype.isAddressPair = function() {
       port = value.slice(idx + 1);
 
       try {
-        ip6 = new ipv6.Address(ip);
+        ip4 = new Address4(ip);
+        ip6 = new Address6(ip);
         // not valid as ipv4 and not valid as ipv6
-        if (!ip6.is4() && !ip6.valid) {
+        if (!ip4.valid && !ip6.valid) {
           throw new Error('Invalid IP');
         }
       } catch (e1) {
@@ -884,16 +887,16 @@ Chain.prototype.isIP = function() {
   this._pushValidator({
     name: 'isIP',
     func: function(value, baton, callback) {
-      var ip,
-          ip6;
+      var ip, ip4, ip6;
       if (!value || value === '' || typeof(value) !== 'string') {
         callback('IP address is not a string');
         return;
       }
       try {
-        ip6 = new ipv6.Address(value);
+        ip4 = new Address4(value);
+        ip6 = new Address6(value);
         // not valid as ipv4 and not valid as ipv6
-        if (!ip6.is4() && !ip6.valid) {
+        if (!ip4.valid && !ip6.valid) {
           throw new Error('Invalid IP');
         }
         ip = normalizeIP(value);
@@ -920,7 +923,7 @@ Chain.prototype.isIPv4 = function() {
     name: 'isIPv4',
     func: function(value, baton, callback) {
       var normalized,
-        ip4 = new ipv4.Address(value),
+        ip4 = new Address4(value),
         valid = ip4.valid;
 
       if (!valid) {
@@ -953,7 +956,7 @@ Chain.prototype.isIPv6 = function() {
   this._pushValidator({
     name: 'isIPv6',
     func: function(value, baton, callback) {
-      var ip6 = new ipv6.Address(value),
+      var ip6 = new Address6(value),
         valid = ip6.valid,
         normalized;
 
@@ -992,8 +995,9 @@ Chain.prototype.isHostnameOrIp = function() {
         return;
       }
 
-      var ip = new ipv6.Address(value);
-      if (ip.valid || ip.is4()) {
+      var ip4 = new Address4(value),
+          ip6 = new Address6(value);
+      if (ip4.valid || ip6.valid) {
         callback(null, value);
         return;
       }
@@ -1022,7 +1026,7 @@ Chain.prototype.isAllowedFQDNOrIP = function(blacklist) {
   this._pushValidator({
     name: 'isAllowedFQDNOrIp',
     func: function(value, baton, callback) {
-      var normalized, i, ip;
+      var normalized, i, ip4, ip6;
 
       if (validators.isHostname(value)) {
         normalized = value.replace(/\.$/, '');
@@ -1050,8 +1054,9 @@ Chain.prototype.isAllowedFQDNOrIP = function(blacklist) {
         return;
       }
 
-      ip = new ipv6.Address(value);
-      if (ip.valid || ip.is4()) {
+      ip4 = new Address4(value);
+      ip6 = new Address6(value);
+      if (ip4.valid || ip6.valid) {
         callback(null, value);
         return;
       }

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -345,7 +345,7 @@ var encode = function(str) {
   }
 
   return str;
-}
+};
 
 var decode = function (str) {
   if (!~str.indexOf('&')) return str;
@@ -368,7 +368,7 @@ var decode = function (str) {
   str = str.replace(/&amp;/g, '&');
 
   return str;
-}
+};
 
 
 /**
@@ -1602,7 +1602,7 @@ Chain.prototype.numItems = function(min, max) {
   this._numItemsValidator = {
     'min': min,
     'max': max
-  }
+  };
 
   v.func = function(value, baton, callback) {
     callback(null, value);
@@ -2409,7 +2409,7 @@ Valve.prototype.check = function(_obj, options, callback) {
   }
 
   if (options.strict) {
-    for (key in obj) {
+    for (var key in obj) {
       if (obj.hasOwnProperty(key) && !this.schema.hasOwnProperty(key)) {
         callback({'key': key, 'message': 'This key is not allowed'});
         return;
@@ -2426,7 +2426,7 @@ Valve.prototype.check = function(_obj, options, callback) {
     if (finalValidator) {
       finalValidator(cleaned, function(err, finalCleaned) {
         if (err instanceof Error) {
-          throw new Error('err argument must be a swiz error object')
+          throw new Error('err argument must be a swiz error object');
         }
         callback(err, finalCleaned);
       });
@@ -2517,7 +2517,7 @@ Valve.prototype.checkUpdate = function(existing, obj, callback) {
   if (this.finalValidator) {
     this.finalValidator.call(null, cleaned, function(err, finalCleaned) {
       if (err instanceof Error) {
-        throw new Error('err argument must be a swiz error object')
+        throw new Error('err argument must be a swiz error object');
       }
       callback(err, finalCleaned);
     });

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "test": "./scripts/tests.sh"
   },
   "engines": {
-    "node": ">= 0.4.0"
+    "node": ">= 0.10.0"
   },
   "dependencies": {
     "async": "0.1.18",
     "validator": "3.41.1",
-    "ipv6": "2.0.2",
+    "ip-address": "5.8.6",
     "elementtree": "0.1.6",
     "sprintf": "0.1.1"
   },

--- a/tests/test-valve.js
+++ b/tests/test-valve.js
@@ -27,14 +27,14 @@ var F = swiz.struct.Field;
 function invalidIpFailMsgAsserter(assert, msg) {
   return function(err, cleaned) {
     assert.deepEqual(err.message, 'Invalid IP', msg);
-  }
+  };
 }
 
 function equalAsserter(assert, expected, msg) {
   return function(err, cleaned) {
     assert.ifError(err);
     assert.deepEqual(cleaned, expected, msg);
-  }
+  };
 }
 
 // Mock set of serialization defs
@@ -929,7 +929,7 @@ exports['test_validate_ip'] = function(test, assert) {
   });
 
   v.check({a: '2001:0db8:0:0:1:0:0:127.0.0.1'}, function(err, unused) {
-   assert.deepEqual(err.message, 'Incorrect number of groups found', 'Malformed IPv6 address w/ embedded IPv4 address');
+   assert.deepEqual(err.message, 'Invalid IP', 'Malformed IPv6 address w/ embedded IPv4 address');
   });
 
   var stack_attack = "";

--- a/tests/test-valve.js
+++ b/tests/test-valve.js
@@ -763,6 +763,22 @@ exports['test_isAllowedFQDNOrIP'] = function(test, assert) {
         assert.ok(err);
         callback();
       });
+    },
+
+    function neg10(callback) {
+      var neg = { a: '\t192.168.0.1' };
+      v.check(neg, function(err, cleaned) {
+        assert.ok(err);
+        callback();
+      });
+    },
+
+    function neg11(callback) {
+      var neg = { a: '\tlocalhost' };
+      v.check(neg, function(err, cleaned) {
+        assert.ok(err);
+        callback();
+      });
     }
   ],
 
@@ -790,9 +806,14 @@ exports['test_validate_ipv4'] = function(test, assert) {
     assert.deepEqual(err.message, 'Invalid IPv4', 'IPv4 test (negative case)');
   });
 
-  neg = {a: '12345' };
+  neg = { a: '12345' };
   v.check(neg, function(err, cleaned) {
     assert.deepEqual(err.message, 'Invalid IPv4', 'IPv4 test (negative case 2)');
+  });
+
+  neg = { a: '\t192.168.0.1' };
+  v.check(neg, function(err, cleaned) {
+    assert.deepEqual(err.message, 'Invalid IPv4', 'IPv4 test (negative case 3)');
   });
 
   test.finish();
@@ -836,6 +857,11 @@ exports['test_validate_isAddressPair'] = function(test, assert) {
   obj_ext = { a: '127.0.0.1:444444' };
   v.check(obj_ext, function(err, cleaned) {
     assert.match(err.message, /Port in the address pair is out of range/);
+  });
+
+  obj_ext = { a: '\t0000:0000:0000:0000:0000:0000:0000:0001:22222' };
+  v.check(obj_ext, function(err, cleaned) {
+    assert.match(err.message, /IP address in the address pair is not valid/);
   });
 
   test.finish();


### PR DESCRIPTION
`ipv6` has been deprecated and renamed to `ip-address`:
Old: https://www.npmjs.com/package/ipv6
New: https://www.npmjs.com/package/ip-address

The initial reason for this change is because there are other problems with `ipv6`, and how we were using it, which would allow invalid IPs to be accepted.  A couple new tests have been added to capture this - they would fail before my second commit.

For example `\t127.0.0.1` would be accepted.  To correct this, wherever `ip6.is4()` was previously used we now actually check `Address4.valid`.

For the above example `Address6.v4` would return true, but `Address6.is4()` would return false because `is4()` also checks the value of `Address6.valid`.  Since this IP is not valid IPv6, `is4()` will not return true even if it is a valid IPv4 address.

This means we need to use `Address4.valid` and `Address6.valid` to get the most correct results.

All tests pass.

```
npm run-script test
...

Ran 111 tests in 1.010s

Successes: 111
Failures: 0
Timeouts: 0
Skipped: 0

PASSED
```